### PR TITLE
changed deprecated 'np.bool' to 'bool' as required by new numpy.

### DIFF
--- a/lamar/tasks/mapping.py
+++ b/lamar/tasks/mapping.py
@@ -118,7 +118,7 @@ class Triangulation(Mapping):
                 if valid[-1]:
                     ids.append(p.point3D_id)
                     xyz.append(self.reconstruction.points3D[ids[-1]].xyz)
-        return np.array(valid, np.bool), xyz, ids
+        return np.array(valid, bool), xyz, ids
 
 
 class MeshLifting(Mapping):
@@ -157,7 +157,7 @@ class MeshLifting(Mapping):
         directions = np.ascontiguousarray(directions, dtype=np.float32)
         rays = (origins, directions)
         xyz, valid = self.renderer.compute_intersections(rays)
-        return np.array(valid, np.bool), xyz
+        return np.array(valid, bool), xyz
 
     def get_points3D(self, key, point2D_indices):
         name = self.key2name[key]
@@ -225,4 +225,4 @@ class Hybrid(Mapping):
                     xyz.append(xyz_lift.pop(0))
                     ids.append(ids_lift.pop(0))
         assert len(xyz_tri) == len(ids_tri) == len(xyz_lift) == len(ids_lift) == 0
-        return np.array(valid, np.bool), xyz, ids
+        return np.array(valid, bool), xyz, ids

--- a/lamar/utils/retrieval.py
+++ b/lamar/utils/retrieval.py
@@ -46,7 +46,7 @@ def filter_by_radio(session_q, session_r, keys_q, keys_r, conf: RadioFilterConf)
     assert conf.frac_pairs_filter is not None
     num_pairs_filter = int(np.ceil(conf.frac_pairs_filter * len(keys_r)))
     radio_map = radio_mapping.build_radio_map(session_r, conf.window_us)
-    keep = np.full((len(keys_q), len(keys_r)), False, np.bool)
+    keep = np.full((len(keys_q), len(keys_r)), False, bool)
     keyr2idx = {k: i for i, k in enumerate(keys_r)}
     without_radios = []
     def _worker_fn(i):

--- a/scantools/viz/alignment.py
+++ b/scantools/viz/alignment.py
@@ -35,7 +35,7 @@ def plot_pnp_inliers(qname: str, refs: List[str], ret: Dict, data_root: Path, nu
 
 
 def plot_raw_matches(qname: str, refs: List[str], match_data: Dict, data_root: Path, **args):
-    match_data = {**match_data, 'inliers': np.full(len(match_data['indices']), True, np.bool)}
+    match_data = {**match_data, 'inliers': np.full(len(match_data['indices']), True, bool)}
     plot_pnp_inliers(qname, refs, match_data, data_root, **args)
 
 


### PR DESCRIPTION
changed deprecated 'np.bool' to 'bool' as required by new numpy. See https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

fixes the following crash in mapping: AttributeError: module 'numpy' has no attribute 'bool'. `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.