### PR TITLE
Compress depth maps

### DIFF
--- a/scantools/utils/io.py
+++ b/scantools/utils/io.py
@@ -64,7 +64,7 @@ else:
         mask = (depth > np.iinfo(dtype).max) | (depth < 0)
         depth[mask] = 0  # avoid overflow
         im = PIL.Image.fromarray(depth.round().astype(dtype))
-        im.save(path)
+        im.save(path, format='PNG', compress_level=9)
 
 
 try:


### PR DESCRIPTION
Lossless compression. Example for an image with 3x3 tiling (800x600 size):

| Before      |  After compression     |
|-------|-------|
| 299.4 KiB      |   295.6 KiB    |

PS: it is not a big difference, but for large dataset could be useful.

