### PR TITLE
Convert dng images to jpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN python3 -m pip install --no-deps \
         plyfile==1.0.3 \
         pytijo==0.0.2 \
         pyzbar-upright==0.1.8 \
+        rawpy==0.19.1 \
         scipy==1.11.4
 RUN cd lamar && python3 -m pip install -e .[scantools] --no-deps
 WORKDIR /lamar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ scantools = [
     "plyfile==1.0.3",
     "pytijo==0.0.2",
     "pyzbar-upright==0.1.8",
+    "rawpy==0.19.1",
     "scipy==1.11.4",
 ]
 dev = [

--- a/scantools/scanners/navvis/ocamlib.py
+++ b/scantools/scanners/navvis/ocamlib.py
@@ -256,8 +256,10 @@ def undistort(ocam_model,
     # load image
     src = cv2.imread(input_image_path, cv2.IMREAD_IGNORE_ORIENTATION | cv2.IMREAD_COLOR)
     height, width = src.shape[:2]
-    assert width > height, (height, width, input_image_path)
-
+    assert width > height, (
+        f"Error: Width ({width}) should be greater than height ({height}). "
+        f"Found in file: {input_image_path}"
+    )
     # remap and save image
     save_remaped_image(src, mapx, mapy, output_image_path)
 

--- a/scantools/utils/io.py
+++ b/scantools/utils/io.py
@@ -66,6 +66,23 @@ else:
         im = PIL.Image.fromarray(depth.round().astype(dtype))
         im.save(path, format='PNG', compress_level=9)
 
+    def convert_dng_to_jpg(dng_path: Path):
+        try:
+            import rawpy  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            raise ImportError("rawpy not installed. Please run: pip install rawpy")
+
+        if not dng_path.exists():
+            raise FileNotFoundError(f'Input DNG file does not exist: {dng_path}')
+        with rawpy.imread(str(dng_path)) as raw:
+            rgb = raw.postprocess(
+                use_camera_wb=True,
+                output_color=rawpy.ColorSpace.sRGB,
+                no_auto_bright=True,
+                user_flip=0,  # Ignore any flip information; 0 means no flip
+            )
+            image = PIL.Image.fromarray(rgb)
+            image.save(str(dng_path.with_suffix(".jpg")), format='JPEG', quality=100)
 
 try:
     import cv2


### PR DESCRIPTION
If no jpg images were found, try converting dng images to jpg.

This occurs when you don't have access to the `datasets_proc/` folder,
but only to the `.nvd` (from Navvis cloud) + `datasets_rec/` folder.