### PR TITLE
Faster pose estimation, support for PoseLib and LightGlue

### DIFF
--- a/lamar/tasks/feature_matching.py
+++ b/lamar/tasks/feature_matching.py
@@ -33,6 +33,15 @@ class FeatureMatching:
                 },
             },
         },
+        'lightglue': {
+            'name': 'lightglue',
+            'hloc': {
+                'model': {
+                    'name': 'lightglue',
+                    'features': 'superpoint',
+                },
+            },
+        },
         'mnn': {
             'name': 'mnn',
             'hloc': {

--- a/lamar/tasks/pose_estimation.py
+++ b/lamar/tasks/pose_estimation.py
@@ -214,7 +214,7 @@ class RigPoseEstimation(PoseEstimation):
                 query_names, cameras, T_cams2rig,
                 ref_key_names,
                 self.recover_matches_2d3d,
-                self.config['pnp_error_multiplier'],
+                self.config,
                 return_covariance=self.return_covariance
             )
             if pose is not None:

--- a/lamar/tasks/pose_estimation.py
+++ b/lamar/tasks/pose_estimation.py
@@ -33,6 +33,7 @@ class PoseEstimationPaths:
             root / 'pose_estimation' / query_id / ref_id
             / config['features']['name'] / config['matches']['name']
             / config['pairs']['name'] / config['mapping']['name'] / config['name']
+            / config['estimator']
         )
         self.poses = self.workdir / 'poses.txt'
         self.config = self.workdir / 'configuration.json'
@@ -145,6 +146,7 @@ class PoseEstimation:
 class SingleImagePoseEstimation(PoseEstimation):
     method = {
         'name': 'single_image',
+        'estimator': 'pycolmap',
         'pnp_error_multiplier': 3.0,
     }
 
@@ -167,7 +169,7 @@ class SingleImagePoseEstimation(PoseEstimation):
                 camera,
                 ref_key_names,
                 self.recover_matches_2d3d,
-                self.config['pnp_error_multiplier'],
+                self.config,
                 return_covariance=self.return_covariance
             )
             if pose is not None:
@@ -185,6 +187,7 @@ class SingleImagePoseEstimation(PoseEstimation):
 class RigPoseEstimation(PoseEstimation):
     method = {
         'name': 'rig',
+        'estimator': 'pycolmap',
         'pnp_error_multiplier': 1.0
     }
 
@@ -229,6 +232,7 @@ class RigPoseEstimation(PoseEstimation):
 class RigSinglePoseEstimation(SingleImagePoseEstimation):
     method = {
         'name': 'rig_single',
+        'estimator': 'pycolmap',
         'pnp_error_multiplier': 1.0
     }
 
@@ -303,11 +307,13 @@ class DensePoseEstimation(PoseEstimation):
 class SingleImageDensePoseEstimation(DensePoseEstimation, SingleImagePoseEstimation):
     method = {
         'name': 'dense_single_image',
+        'estimator': 'pycolmap',
         'pnp_error_multiplier': 3.0,
     }
 
 class RigDensePoseEstimation(DensePoseEstimation, RigPoseEstimation):
     method = {
         'name': 'dense_rig',
+        'estimator': 'pycolmap',
         'pnp_error_multiplier': 1.0,
     }

--- a/lamar/utils/localization.py
+++ b/lamar/utils/localization.py
@@ -104,7 +104,8 @@ def estimate_camera_pose(query: str, camera: Camera,
 def estimate_camera_pose_rig(queries: List[str], cameras: List[Camera], T_cams2rig: List[Pose],
                              refs_key_names: List[List[Tuple[KeyType, str]]],
                              recover_matches: Callable,
-                             pnp_error_multiplier: float, return_covariance: bool) -> Pose:
+                             config: Dict[str, Any],
+                             return_covariance: bool) -> Tuple[Pose, Dict[str, Any]]:
     matches_2d3d_list = []
     keypoint_noises = []
     for query, ref_key_names in zip(queries, refs_key_names):
@@ -112,29 +113,46 @@ def estimate_camera_pose_rig(queries: List[str], cameras: List[Camera], T_cams2r
         matches_2d3d_list.append(matches_2d3d)
         keypoint_noises.append(matches_2d3d['keypoint_noise'])
 
-    p2d_m_list = [m['kp_q'] for m in matches_2d3d_list]
-    p3d_m_list = [m['p3d'] for m in matches_2d3d_list]
+    points_2d = [m['kp_q'] for m in matches_2d3d_list]
+    points_3d = [m['p3d'] for m in matches_2d3d_list]
     camera_dicts = [camera.asdict for camera in cameras]
     rel_poses = [T.inverse() for T in T_cams2rig]
     qvecs = [p.qvec for p in rel_poses]
     tvecs = [p.t for p in rel_poses]
     keypoint_noise = np.mean(keypoint_noises)
+    inlier_threshold = config['pnp_error_multiplier'] * keypoint_noise
 
-    ret = pycolmap.rig_absolute_pose_estimation(
-        p2d_m_list, p3d_m_list, camera_dicts, qvecs,
-        tvecs, pnp_error_multiplier * keypoint_noise,
-        return_covariance=return_covariance)
-
-    if ret['success']:
-        if return_covariance:
-            ret['covariance'] *= keypoint_noise ** 2
-            # the covariance returned by pycolmap is on the left side,
-            # which is the right side of the inverse.
-            pose = Pose(*Pose(ret['qvec'], ret['tvec']).inv.qt, ret['covariance'])
+    if config['estimator'] == 'pycolmap':
+        ret = pycolmap.rig_absolute_pose_estimation(
+            points_2d, points_3d, camera_dicts, qvecs, tvecs, inlier_threshold,
+            return_covariance=return_covariance)
+        if ret['success']:
+            if return_covariance:
+                ret['covariance'] *= keypoint_noise ** 2
+                # the covariance returned by pycolmap is on the left side,
+                # which is the right side of the inverse.
+                pose = Pose(*Pose(ret['qvec'], ret['tvec']).inv.qt, ret['covariance'])
+            else:
+                pose = Pose(ret['qvec'], ret['tvec']).inv
         else:
-            pose = Pose(ret['qvec'], ret['tvec']).inv
+            pose = None
+    elif config['estimator'] == 'poselib':
+        if poselib is None:
+            raise ImportError('Could not import PoseLib - did you forget to install it?')
+        if return_covariance:
+            raise ValueError('PoseLib does not support return_covariance=True')
+        rel_poses_poselib = []
+        for q, t in zip(qvecs, tvecs):
+            p = poselib.CameraPose()
+            p.q = q
+            p.t = t
+            rel_poses_poselib.append(p)
+        pose, ret = poselib.estimate_generalized_absolute_pose(
+            points_2d, points_3d, rel_poses_poselib, camera_dicts,
+            {'max_reproj_error': inlier_threshold}, {})
+        pose = Pose(pose.q, pose.t).inv
     else:
-        pose = None
+        raise NotImplementedError(f'Unknown estimator: {config["estimator"]}')
 
     ret = {**ret, 'matches_2d3d_list': matches_2d3d_list}
     return pose, ret


### PR DESCRIPTION
- x100 faster pose estimation by optimizing `recover_matches_2d3d`
- feature matching with LightGlue
- Absolute pose estimation for single-image and rig with PoseLib - slightly better than pycolmap
```
LIN
  query_phone
    pycolmap: 57.1 / 71.5
    poselib:  60.0 / 72.0
  query_hololens
    pycolmap: 69.2 / 83.4
    poselib:  70.5 / 82.7
HGE
  query_phone
    pycolmap: 45.5 / 60.8
    poselib:  46.7 / 60.6
  query_hololens
    pycolmap: 56.6 / 69.4
    poselib:  57.4 / 69.5
```