### PR TITLE
Single-frame Benchmarking Page & Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     <img src="assets/logos.svg" alt="Logo" height="40">
 </p>
   <h2 align="center">ECCV 2022</h2>
-  <h3 align="center"><a href="https://lamar.ethz.ch/">Project Page</a> | <a href = "https://www.codabench.org/competitions/7918">Benchmark Page</a> | <a href="https://youtu.be/32XsRli2coo">Video</a></h3>
+  <h3 align="center"><a href="https://lamar.ethz.ch/">Project Page</a> | <a href="https://www.codabench.org/competitions/7918">Benchmark Page</a> | <a href="https://youtu.be/32XsRli2coo">Video</a></h3>
   <div align="center"></div>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -198,12 +198,25 @@ _Test queries:_
 python -m lamar.combine_results \
   --cab_phone_path path/to/poses_CAB_phone.txt [...] \
   --description path/to/description.txt \
-  --output_dir ./result/
+  --output_dir ./outputs/
 ```
 
 - Submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
 
-:warning: Any public entries should have a name and valid link on the leaderboard. The description file should contain details about the submission (i.e, what methods, what thresholds / hyperparameters, ...). 
+:warning: Any public entries should have a name and valid link on the leaderboard.
+The description file should contain details about the submission (i.e, what methods, what thresholds / hyperparameters, ...).
+Sample description file:
+
+```
+Retrieval Features: Fusion (NetVLAD, APGeM);
+Local Features: SuperPoint;
+Feature Matching: LightGlue;
+Description:
+Default lamar-benchmark parameters for extractors, matchers, and pipeline.
+Retrieved top 10 images for both mapping and localization with frustum filtering for mapping.
+PnP error multiplier 3 for single-image, 1 for rigs.
+
+```
 
 :four: __Workflow:__ the benchmarking pipeline is designed such that
 - the mapping and localization process is split into modular steps listed in [`lamar/tasks/`](./lamar/tasks/)

--- a/README.md
+++ b/README.md
@@ -189,8 +189,21 @@ This executes two steps:
 
 :three: __Obtain the evaluation results:__
 
-- validation queries: the script print the localization recall.
-- test queries: combine results for all locations / devices in a single zip file using `python -m lamar.combine_results --cab_phone_path poses_CAB_phone.txt [...] --output_dir ./result/` and submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
+_Validation queries:_ the script print the localization recall.
+
+_Test queries:_
+- Combine results for all locations / devices in a single zip file using
+
+```
+python -m lamar.combine_results \
+  --cab_phone_path path/to/poses_CAB_phone.txt [...] \
+  --description path/to/description.txt \
+  --output_dir ./result/
+```
+
+- Submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
+
+:warning: Any public entries should have a name and valid link on the leaderboard. The description file should contain details about the submission (i.e, what methods, what thresholds / hyperparameters, ...). 
 
 :four: __Workflow:__ the benchmarking pipeline is designed such that
 - the mapping and localization process is split into modular steps listed in [`lamar/tasks/`](./lamar/tasks/)

--- a/README.md
+++ b/README.md
@@ -189,19 +189,21 @@ This executes two steps:
 
 :three: __Obtain the evaluation results:__
 
-_Validation queries:_ the script print the localization recall.
+_Validation queries:_ the script prints the localization recall.
 
 _Test queries:_
-- Combine results for all locations / devices in a single zip file using
+1. Combine results for all locations / devices in a single zip file using
 
 ```
 python -m lamar.combine_results \
-  --cab_phone_path path/to/poses_CAB_phone.txt [...] \
+  --cab_phone_path path/to/poses_CAB_phone.txt \
+  --cab_hololens_path path/to/poses_CAB_hololens.txt \
+  [...] \
   --description path/to/description.txt \
   --output_dir ./outputs/
 ```
 
-- Submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
+2. Submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
 
 :warning: Any public entries should have a name and valid link on the leaderboard.
 The description file should contain details about the submission (i.e, what methods, what thresholds / hyperparameters, ...).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     <img src="assets/logos.svg" alt="Logo" height="40">
 </p>
   <h2 align="center">ECCV 2022</h2>
-  <h3 align="center"><a href="https://lamar.ethz.ch/">Project Page</a> | <a href="https://youtu.be/32XsRli2coo">Video</a></h3>
+  <h3 align="center"><a href="https://lamar.ethz.ch/">Project Page</a> | <a href = "https://www.codabench.org/competitions/7918">Benchmark Page</a> | <a href="https://youtu.be/32XsRli2coo">Video</a></h3>
   <div align="center"></div>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This executes two steps:
 :three: __Obtain the evaluation results:__
 
 - validation queries: the script print the localization recall.
-- test queries: until the benchmark leaderboard is up and running, please send the predicted pose files to <a href="&#x6d;ailto&#58;lamar-benchmark&#x40;sympa.ethz.ch">lamar-benchmark&#x40;sympa.ethz.ch</a> :warning: we will only accept at most 2 submissions per user per week.
+- test queries: combine results for all locations / devices in a single zip file using `python -m lamar.combine_results --cab_phone_path poses_CAB_phone.txt [...] --output_dir ./result/"` and submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
 
 :four: __Workflow:__ the benchmarking pipeline is designed such that
 - the mapping and localization process is split into modular steps listed in [`lamar/tasks/`](./lamar/tasks/)
@@ -285,7 +285,8 @@ Like the evaluation data, the raw data is accessed through [the dataset page](ht
 - [x] Ground truthing pipeline
 - [x] iOS capture app
 - [x] Full raw data
-- [ ] Leaderboard and evaluation server
+- [x] Leaderboard and evaluation server
+- [ ] Leaderboard for sequence metrics
 - [ ] 3D dataset viewer
 
 ## BibTex citation

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This executes two steps:
 :three: __Obtain the evaluation results:__
 
 - validation queries: the script print the localization recall.
-- test queries: combine results for all locations / devices in a single zip file using `python -m lamar.combine_results --cab_phone_path poses_CAB_phone.txt [...] --output_dir ./result/"` and submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
+- test queries: combine results for all locations / devices in a single zip file using `python -m lamar.combine_results --cab_phone_path poses_CAB_phone.txt [...] --output_dir ./result/` and submit the zip to the [benchmark page](https://www.codabench.org/competitions/7918/).
 
 :four: __Workflow:__ the benchmarking pipeline is designed such that
 - the mapping and localization process is split into modular steps listed in [`lamar/tasks/`](./lamar/tasks/)

--- a/lamar/combine_results.py
+++ b/lamar/combine_results.py
@@ -12,9 +12,43 @@ def assert_valid_txt_path(path: Path):
     assert path.suffix == ".txt"
 
 
+def combine_results(description_path: Path, results_paths: dict[str, Path], output_dir: Path):
+    # Generate timestamp for the zip file name.
+    timestamp = datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S")
+    zip_filename = output_dir / f"submission_{timestamp}.zip"
+    
+    # Create the zip file with existing paths.
+    logger.info(f"Creating zip file at {zip_filename}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+        # Add the description file to the zip.
+        logger.info(f"Adding description file from {description_path} to zip")
+        assert_valid_txt_path(description_path)
+        zipf.write(description_path, arcname="description.txt")
+        for name, path in results_paths.items():
+            split = name.split("_")
+            assert len(split) == 3
+            assert split[-1] == "path"
+            split = split[:-1]
+            if path is None:
+                logger.warning(f"No path provided for [{split}], skipping...")
+                continue
+            logger.info(f"Adding [{split}] file from {path} to zip")
+            assert_valid_txt_path(path)
+            zipf.write(path, arcname=f"{split[0].upper()}_query_{split[1]}.txt")
+    logger.info(f"Successfully created zip file at {zip_filename}")
+
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Combine estimated poses from multiple scenes / devices in a zip file for evaluation."
+    )
+    parser.add_argument(
+        "--description_path",
+        type=Path,
+        required=True,
+        help="Path to a text file containing description of the submission.",
     )
     parser.add_argument(
         "--cab_phone_path",
@@ -53,12 +87,6 @@ if __name__ == '__main__':
         help="File containing the HGE HoloLens estimated poses.",
     )
     parser.add_argument(
-        "--description_path",
-        type=Path,
-        required=True,
-        help="Path to a text file containing description of the submission.",
-    )
-    parser.add_argument(
         "--output_dir",
         type=Path,
         required=True,
@@ -68,27 +96,8 @@ if __name__ == '__main__':
     output_dir = args.pop("output_dir")
     description_path = args.pop("description_path")
 
-    # Generate timestamp for the zip file name.
-    timestamp = datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S")
-    zip_filename = output_dir / f"result_{timestamp}.zip"
-    
-    # Create the zip file with existing paths.
-    logger.info(f"Creating zip file at {zip_filename}")
-    output_dir.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
-        # Add the description file to the zip.
-        logger.info(f"Adding description file from {description_path} to zip")
-        assert_valid_txt_path(description_path)
-        zipf.write(description_path, arcname="description.txt")
-        for name, path in args.items():
-            split = name.split("_")
-            assert len(split) == 3
-            assert split[-1] == "path"
-            split = split[:-1]
-            if path is None:
-                logger.warning(f"No path provided for [{split}], skipping...")
-                continue
-            logger.info(f"Adding [{split}] file from {path} to zip")
-            assert_valid_txt_path(path)
-            zipf.write(path, arcname=f"{split[0].upper()}_query_{split[1]}.txt")
-    logger.info(f"Successfully created zip file at {zip_filename}")
+    combine_results(
+        description_path=description_path,
+        results_paths=args,
+        output_dir=output_dir,
+    )

--- a/lamar/combine_results.py
+++ b/lamar/combine_results.py
@@ -51,33 +51,28 @@ if __name__ == '__main__':
         help="Output directory where the zip will be saved.",
         required=True,
     )
-    args = parser.parse_args()
-    
-    # Define all arguments and their human-readable names.
-    arg_paths = {
-        ("CAB", "phone"): args.cab_phone_path,
-        ("LIN", "phone"): args.lin_phone_path,
-        ("HGE", "phone"): args.hge_phone_path,
-        ("CAB", "hololens"): args.cab_hololens_path,
-        ("LIN", "hololens"): args.lin_hololens_path,
-        ("HGE", "hololens"): args.hge_hololens_path,
-    }
-    
+    args = parser.parse_args().__dict__
+    output_dir = args.pop("output_dir")
+
     # Generate timestamp for the zip file name.
     timestamp = datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S")
-    zip_filename = args.output_dir / f"result_{timestamp}.zip"
+    zip_filename = output_dir / f"result_{timestamp}.zip"
     
     # Create the zip file with existing paths.
     logger.info(f"Creating zip file at {zip_filename}")
-    args.output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
-        for split, path in arg_paths.items():
+        for name, path in args.items():
+            split = name.split("_")
+            assert len(split) == 3
+            assert split[-1] == "path"
+            split = split[:-1]
             if path is None:
-                logger.warning(f"No path provided for [{split}], skipping")
+                logger.warning(f"No path provided for [{split}], skipping...")
                 continue
             assert path.exists()
             assert path.is_file()
             assert path.suffix == ".txt", f"Expected .txt file, got {path.suffix}"
             logger.info(f"Adding [{split}] file from {path} to zip")
-            zipf.write(path, arcname=f"{split[0]}_query_{split[1]}.txt")
+            zipf.write(path, arcname=f"{split[0].upper()}_query_{split[1]}.txt")
     logger.info(f"Successfully created zip file at {zip_filename}")

--- a/lamar/combine_results.py
+++ b/lamar/combine_results.py
@@ -1,0 +1,83 @@
+import argparse
+import datetime
+import zipfile
+from pathlib import Path
+
+from . import logger
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Combine estimated poses from multiple scenes / devices in a zip file for evaluation."
+    )
+    parser.add_argument(
+        "--cab_phone_path",
+        type=Path,
+        default=None,
+        help="File containing the CAB phone estimated poses.",
+    )
+    parser.add_argument(
+        "--lin_phone_path",
+        type=Path,
+        default=None,
+        help="File containing the LIN phone estimated poses.",
+    )
+    parser.add_argument(
+        "--hge_phone_path",
+        type=Path,
+        default=None,
+        help="File containing the HGE phone estimated poses.",
+    )
+    parser.add_argument(
+        "--cab_hololens_path",
+        type=Path,
+        default=None,
+        help="File containing the CAB HoloLens estimated poses.",
+    )
+    parser.add_argument(
+        "--lin_hololens_path",
+        type=Path,
+        default=None,
+        help="File containing the LIN HoloLens estimated poses.",
+    )
+    parser.add_argument(
+        "--hge_hololens_path",
+        type=Path,
+        default=None,
+        help="File containing the HGE HoloLens estimated poses.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=Path,
+        help="Output directory where the zip will be saved.",
+        required=True,
+    )
+    args = parser.parse_args()
+    
+    # Define all arguments and their human-readable names.
+    arg_paths = {
+        ("CAB", "phone"): args.cab_phone_path,
+        ("LIN", "phone"): args.lin_phone_path,
+        ("HGE", "phone"): args.hge_phone_path,
+        ("CAB", "hololens"): args.cab_hololens_path,
+        ("LIN", "hololens"): args.lin_hololens_path,
+        ("HGE", "hololens"): args.hge_hololens_path,
+    }
+    
+    # Generate timestamp for the zip file name.
+    timestamp = datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S")
+    zip_filename = args.output_dir / f"result_{timestamp}.zip"
+    
+    # Create the zip file with existing paths.
+    logger.info(f"Creating zip file at {zip_filename}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for split, path in arg_paths.items():
+            if path is None:
+                logger.warning(f"No path provided for [{split}], skipping")
+                continue
+            assert path.exists()
+            assert path.is_file()
+            assert path.suffix == ".txt", f"Expected .txt file, got {path.suffix}"
+            logger.info(f"Adding [{split}] file from {path} to zip")
+            zipf.write(path, arcname=f"{split[0]}_query_{split[1]}.txt")
+    logger.info(f"Successfully created zip file at {zip_filename}")

--- a/lamar/combine_results.py
+++ b/lamar/combine_results.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from . import logger
 
 def assert_valid_txt_path(path: Path):
-    """Assert that the path is valid."""
-    assert path.exists(), f"Path does not exist: {path}"
-    assert path.is_file(), f"Path is not a file: {path}"
-    assert path.suffix == ".txt", f"Expected .txt file, got {path.suffix}"
+    """Assert that the txt path is valid."""
+    assert path.exists()
+    assert path.is_file()
+    assert path.suffix == ".txt"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With some collaborators, we are building a CodaBench Competition for an upcoming project & its related challenge. Since the new challenge uses the same metrics for the single-image/rig setup, we reused our work to create a LaMAR Competition too.

Link: https://www.codabench.org/competitions/7918

This PR:
- Adds links to benchmarking page (containing leaderboard).
- Adds script for merging results of different scenes / devices into a single zip file for submission.

TODO:
- [x] Rerun and submit an initial baseline (Fusion + SP + LightGlue with default parameters).
- [x] Make benchmarking page public.

TL;DR: Users need to be approved before submitting. 5 submissions / user / day. Leaderboard with overall recall @ thresholds & per-device split + detailed results. [Main Leaderboard](https://github.com/user-attachments/assets/807ccb32-31c6-4e6f-b809-bd6be9c42ad9), [Detailed submission results](https://github.com/user-attachments/assets/e849a92f-eee8-45ab-aef3-ec884a6ef967).

Note that the current competition does not support sequence metrics. Given CodaBench limitations (single leaderboard per competition, single phase running at a given time), the sequence evaluation should most likely be a different competition. In the meanwhile, we allow users to evaluate sequence methods and tag their submissions accordingly, but ask them to keep the submissions private.